### PR TITLE
カレンダーの時間修正時にonChangeごとに更新リクエストをしないようにする

### DIFF
--- a/components/calendar_month.tsx
+++ b/components/calendar_month.tsx
@@ -81,6 +81,11 @@ export const CalendarMonth: React.FC<MonthProps> = ({
                       false
                     )
                   }
+                  onKeyPress={(e) => {
+                    if (e.key === "Enter") {
+                      handleUpdateDay("actual", (e.target as HTMLInputElement).value, dayIndex, false)
+                    }
+                  }}
                   onChange={(e) =>
                     handleUpdateDay("scheduled", e.target.value, dayIndex, true)
                   }
@@ -99,6 +104,11 @@ export const CalendarMonth: React.FC<MonthProps> = ({
                       false
                     )
                   }
+                  onKeyPress={(e) => {
+                    if (e.key === "Enter") {
+                      handleUpdateDay("actual", (e.target as HTMLInputElement).value, dayIndex, false)
+                    }
+                  }}
                   onChange={(e) =>
                     handleUpdateDay("actual", e.target.value, dayIndex, true)
                   }

--- a/components/calendar_month.tsx
+++ b/components/calendar_month.tsx
@@ -83,7 +83,7 @@ export const CalendarMonth: React.FC<MonthProps> = ({
                   }
                   onKeyPress={(e) => {
                     if (e.key === "Enter") {
-                      handleUpdateDay("actual", (e.target as HTMLInputElement).value, dayIndex, false)
+                      (e.target as HTMLInputElement).blur();
                     }
                   }}
                   onChange={(e) =>
@@ -106,7 +106,7 @@ export const CalendarMonth: React.FC<MonthProps> = ({
                   }
                   onKeyPress={(e) => {
                     if (e.key === "Enter") {
-                      handleUpdateDay("actual", (e.target as HTMLInputElement).value, dayIndex, false)
+                      (e.target as HTMLInputElement).blur();
                     }
                   }}
                   onChange={(e) =>

--- a/components/calendar_month.tsx
+++ b/components/calendar_month.tsx
@@ -1,53 +1,115 @@
-import {CalendarMonthTemplate} from 'components/calendar_month_template';
-import {Week} from 'lib/calendar';
-import {CalendarDate} from 'lib/calendar_date';
-import {CalendarMonthData} from 'lib/calendar_month_data';
-import {CalendarMonthView} from 'lib/calendar_month_view';
-import {FloatingLabel, Form} from 'react-bootstrap';
+import { CalendarMonthTemplate } from "components/calendar_month_template";
+import { Week } from "lib/calendar";
+import { CalendarDate } from "lib/calendar_date";
+import { CalendarMonthData } from "lib/calendar_month_data";
+import { CalendarMonthView } from "lib/calendar_month_view";
+import { FloatingLabel, Form } from "react-bootstrap";
 
 type MonthProps = {
   year: number;
   month: number;
   monthDataList: Array<CalendarMonthData>;
   workingWeek: Week;
-  handleUpdateDay: (attributeName: string, value: boolean | string, dayIndex: number) => void;
-}
+  handleUpdateDay: (
+    attributeName: string,
+    value: boolean | string,
+    dayIndex: number,
+    onlyUpdateState: boolean
+  ) => void;
+};
 
-export const CalendarMonth: React.FC<MonthProps>= ({ year, month, workingWeek, handleUpdateDay, monthDataList }) => {
+export const CalendarMonth: React.FC<MonthProps> = ({
+  year,
+  month,
+  workingWeek,
+  handleUpdateDay,
+  monthDataList,
+}) => {
   const builder = new CalendarMonthView(year, month);
   const tDBody = (dayNumber: number | null, index: number) => {
-    if(dayNumber === null) { return <td key={index}></td> }
+    if (dayNumber === null) {
+      return <td key={index}></td>;
+    }
 
     const dayIndex = dayNumber - 1;
     const calendarDate = CalendarDate(year, month, dayNumber);
     const day = monthDataList[0].days[dayIndex]; // NOTE: ここでは1つのカレンダーのみ入ってくるので、0番目を参照する
-    let tdClassName = (workingWeek[calendarDate.weekDayName()]) ? 'bg-info' : 'bg-secondary text-light';
-    if(Number(day.actual)) { tdClassName = 'bg-success text-light' }
-    if(day.isHoliday) { tdClassName = 'bg-secondary text-light' }
-    if(day.isInvalid()) { tdClassName = 'bg-warning text-light' }
+    let tdClassName = workingWeek[calendarDate.weekDayName()]
+      ? "bg-info"
+      : "bg-secondary text-light";
+    if (Number(day.actual)) {
+      tdClassName = "bg-success text-light";
+    }
+    if (day.isHoliday) {
+      tdClassName = "bg-secondary text-light";
+    }
+    if (day.isInvalid()) {
+      tdClassName = "bg-warning text-light";
+    }
 
-    return(
+    return (
       <td key={index} className={tdClassName}>
-        {dayNumber}日{calendarDate.isNationalHoliday() && '(祝)'}<br />
-
+        {dayNumber}日{calendarDate.isNationalHoliday() && "(祝)"}
+        <br />
         <Form>
-          <Form.Check type="switch" checked={day.isHoliday} name={'isHoliday'}  label="稼働対象外" className='m-1' onChange={(e) => handleUpdateDay('isHoliday', e.target.checked, dayIndex) } />
+          <Form.Check
+            type="switch"
+            checked={day.isHoliday}
+            name={"isHoliday"}
+            label="稼働対象外"
+            className="m-1"
+            onChange={(e) =>
+              handleUpdateDay("isHoliday", e.target.checked, dayIndex, false)
+            }
+          />
           {day.isWorkingDay() && (
             <>
-              <FloatingLabel controlId="floatingInput" label="予定" className='mb-2' >
-                <Form.Control type="text" value={day.scheduled} name={'scheduled'} onChange={(e) => handleUpdateDay('scheduled', e.target.value, dayIndex)} />
+              <FloatingLabel
+                controlId="floatingInput"
+                label="予定"
+                className="mb-2"
+              >
+                <Form.Control
+                  type="text"
+                  value={day.scheduled}
+                  name={"scheduled"}
+                  onBlur={(e) =>
+                    handleUpdateDay(
+                      "scheduled",
+                      e.target.value,
+                      dayIndex,
+                      false
+                    )
+                  }
+                  onChange={(e) =>
+                    handleUpdateDay("scheduled", e.target.value, dayIndex, true)
+                  }
+                />
               </FloatingLabel>
-              <FloatingLabel controlId="floatingInput" label="実績" >
-                <Form.Control type="text" value={day.actual} name={'actual'} onChange={(e) => handleUpdateDay('actual', e.target.value, dayIndex)} />
+              <FloatingLabel controlId="floatingInput" label="実績">
+                <Form.Control
+                  type="text"
+                  value={day.actual}
+                  name={"actual"}
+                  onBlur={(e) =>
+                    handleUpdateDay(
+                      "actual",
+                      e.target.value,
+                      dayIndex,
+                      false
+                    )
+                  }
+                  onChange={(e) =>
+                    handleUpdateDay("actual", e.target.value, dayIndex, true)
+                  }
+                />
               </FloatingLabel>
             </>
           )}
         </Form>
       </td>
-    )
-  }
+    );
+  };
 
-  return (
-    <CalendarMonthTemplate builder={builder} tDBody={tDBody} />
-  );
+  return <CalendarMonthTemplate builder={builder} tDBody={tDBody} />;
 };

--- a/hooks/use_manage_calendar.ts
+++ b/hooks/use_manage_calendar.ts
@@ -43,9 +43,7 @@ export const useManageCalendar = () => {
 
   const updateMonthsWithLock = async (calendar: Calendar, user: User, monthKey: string) => {
     const entryPath = calendarPath(user, calendar.id);
-    console.log(calendar)
     const docRef = doc(db, entryPath);
-    console.log('updated!!!!!!!!!')
 
     await runTransaction(db, async (transaction) => {
       const docSnapshot = await transaction.get(docRef);
@@ -62,7 +60,7 @@ export const useManageCalendar = () => {
       transaction.update(docRef, { months: calendar.months, lockVersion: calendar.lockVersion });
     }).then(() => {
       updateCalendarForReRender(calendar, monthKey);
-    })
+    });
   }
 
   const updateCalendar = async (user: User, calendar_id: string, name: string, standardTime: number, week: Week) => {
@@ -164,5 +162,6 @@ export const useManageCalendar = () => {
     updateCalendarWithLock,
     updateMonths,
     updateMonthsWithLock,
+    updateCalendarForReRender,
   };
 }

--- a/pages/v2/calendars/[calendar_id]/[year]/[month]/index.tsx
+++ b/pages/v2/calendars/[calendar_id]/[year]/[month]/index.tsx
@@ -23,7 +23,7 @@ const Page: NextPageWithLayout = () => {
   const { user } = useCurrentUser()
   const date = CalendarDate(year && Number(year), month && Number(month), 1);
   const monthKey = date.monthlyKey();
-  const { updateMonthsWithLock } = useManageCalendar();
+  const { updateMonthsWithLock, updateCalendarForReRender } = useManageCalendar();
 
   const handleConfirm = (message: string, action: () => void) => {
     const result = confirm(message);
@@ -48,9 +48,14 @@ const Page: NextPageWithLayout = () => {
       }
     })
   }
-  const handleUpdateDay = async (attributeName: string, value: boolean | string, dayIndex: number): Promise<void> => {
+  const handleUpdateDay = async (attributeName: string, value: boolean | string, dayIndex: number, onlyUpdateState: boolean): Promise<void> => {
     days[dayIndex][attributeName] = value;
     calendar.months[monthKey] = days.map((day: DayObject) => { return(day.toObject()) });
+    if(onlyUpdateState) {
+      updateCalendarForReRender(calendar, monthKey);
+      return
+    }
+
     updateMonthsWithLock(calendar, user, monthKey).then(() => {
       toast('時間を更新しました');
     }).catch((error) => {


### PR DESCRIPTION
変更前だとバックスペースや数字を入れるたびにfirebaseへリクエストしまっていて、体験が微妙だった。
更新リクエストのタイミングを入力後相当に限るようにする。