### PR TITLE
月の時間入力画面で、小数点を含む時間を手入力できる

### DIFF
--- a/lib/days_generator.ts
+++ b/lib/days_generator.ts
@@ -47,8 +47,13 @@ export class DayObject implements DayData {
   }
 
   // NOTE: firestoreに保存するためにオブジェクトに変換する
-  toObject(): DayData {
+  toObjectForStore(): DayData {
     return { day: this.day, scheduled: this.scheduledHour(), actual: this.actualHour(), isHoliday: this.isHoliday };
+  }
+
+  // NOTE:  this.scheduled, this.actualには文字列が入ってくる可能性がある
+  toObject(): DayData {
+    return { day: this.day, scheduled: this.scheduled, actual: this.actual, isHoliday: this.isHoliday };
   }
 }
 

--- a/pages/v2/calendars/[calendar_id]/[year]/[month]/index.tsx
+++ b/pages/v2/calendars/[calendar_id]/[year]/[month]/index.tsx
@@ -50,13 +50,17 @@ const Page: NextPageWithLayout = () => {
     })
   }
   const handleUpdateDay = async (attributeName: string, value: boolean | string, dayIndex: number, onlyUpdateState: boolean): Promise<void> => {
-    days[dayIndex][attributeName] = Number(value);
+    // NOTE: `0.5`を入力するときに途中で `0.` となるので、 `0.` を保持できるように整数へのキャストはしない
+    days[dayIndex][attributeName] = value;
     calendar.months[monthKey] = days.map((day: DayObject) => { return(day.toObject()) });
     if(onlyUpdateState) {
       updateCalendarForReRender(calendar, monthKey);
       return
     }
 
+    // NOTE: 永続化するときは `0.`を入れることはないので整数へのキャストをしていい
+    days[dayIndex][attributeName] = Number(value);
+    calendar.months[monthKey] = days.map((day: DayObject) => { return(day.toObjectForStore()) });
     updateMonthsWithLock(calendar, user, monthKey).then((updated) => {
       if(updated) { toast('時間を更新しました'); }
     }).catch((error) => {


### PR DESCRIPTION
手入力で 0.5 を入れるときに、 `0.`の状態で整数へキャストしてしまっていて、 0.5という入力ができなくなっていたので、それを入力できるように修正します。